### PR TITLE
change the branch from `master` to `main`

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,3 +1,3 @@
 [
-  { "required_api_version": "^2.0.0", "commit": "master" }
+  { "required_api_version": "^2.0.0", "commit": "main" }
 ]


### PR DESCRIPTION
Since this repo does not have `master` branch, users are unable to add this extension to ULauncher

Possibly fixes issue #1 